### PR TITLE
Better Error Codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-## 0.9.0
+# 0.9.1
+
+* Rethrowing native Android and iOS exception as specific ones derived from `EidmsdkException`.
+
+# 0.9.0
 
 * Update native eID mSDK dependencies
 
-## 0.0.1
+# 0.0.1
 
 * Initial release

--- a/android/src/main/kotlin/sk/freevision/eidmsdk/EidmsdkPlugin.kt
+++ b/android/src/main/kotlin/sk/freevision/eidmsdk/EidmsdkPlugin.kt
@@ -100,6 +100,7 @@ class EidmsdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
         // Every method call arguments expected it to be Map<String, Any?>
         if (call.arguments !is Map<*, *>) {
+            // TODO use custom .error() fun with IllegalArgumentException
             result.error(
                 /* errorCode = */ "ERROR_PARSE_ARGUMENTS",
                 /* errorMessage = */ "Error parsing arguments",
@@ -202,11 +203,7 @@ class EidmsdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 channelResult?.success(it)
             } ,
             onFailure = {
-                channelResult?.error(
-                    "ERROR_READ_CERTIFICATE",
-                    "Chyba pri načítaní podpisového certifikátu.",
-                    it.message,
-                )
+                channelResult?.error("Chyba pri načítaní podpisového certifikátu.", it)
             }
         )
 
@@ -221,11 +218,7 @@ class EidmsdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 channelResult?.success(it)
             },
             onFailure = {
-                channelResult?.error(
-                    "ERROR_SIGNING",
-                    "Chyba pri podpisovaní.",
-                    it.message,
-                )
+                channelResult?.error("Chyba pri podpisovaní.", it)
             }
         )
 
@@ -234,5 +227,14 @@ class EidmsdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     companion object {
         private const val TAG: String = "EidmsdkPlugin"
+    }
+
+    /** Universal error handler for any [Throwable]. */
+    private fun Result.error(message: String, e: Throwable) {
+        error(
+            /* errorCode = */ e.javaClass.simpleName,
+            /* errorMessage = */ message,
+            /* errorDetails = */ e.message,
+        )
     }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - eidmsdk (0.9.0):
+  - eidmsdk (0.9.1):
     - Flutter
     - JWTDecode
     - lottie-ios
@@ -31,13 +31,13 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  eidmsdk: 907312cae65036d456cf4b7b4e190ad94ba72d6a
+  eidmsdk: a97f3ea988f9c37e637db041fbc7cafd482e7de4
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  integration_test: 13825b8a9334a850581300559b8839134b124670
+  integration_test: 2d03ab552da9a1f408709a6acf3d7ca4cb3cb307
   JWTDecode: 33e5e26e5ddbd21b2065820894c08fef0cad9509
   lottie-ios: ef1be1f90d54255f08e09d767950e43714661178
   OpenSSL-Universal: 6e1ae0555546e604dbc632a2b9a24a9c46c41ef6
 
 PODFILE CHECKSUM: 70d9d25280d0dd177a5f637cdb0f0b0b12c6a189
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -31,7 +31,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  eidmsdk: a97f3ea988f9c37e637db041fbc7cafd482e7de4
+  eidmsdk: f8cd146c24355be318f05821b210ad6dd0196927
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: 2d03ab552da9a1f408709a6acf3d7ca4cb3cb307
   JWTDecode: 33e5e26e5ddbd21b2065820894c08fef0cad9509

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.9.1"
   fake_async:
     dependency: transitive
     description:

--- a/ios/Classes/EidmsdkPlugin.swift
+++ b/ios/Classes/EidmsdkPlugin.swift
@@ -68,7 +68,7 @@ public class EidmsdkPlugin: NSObject, FlutterPlugin {
       case .success(let certificatesJSONString):
         result(certificatesJSONString)
       case .failure(let error):
-        result(FlutterError(code: "ERROR_READ_CERTIFICATE",
+        result(FlutterError(code: String(describing: error),
                             message: "Chyba pri načítaní podpisového certifikátu.",
                             details: error.localizedDescription))
       }
@@ -111,7 +111,7 @@ public class EidmsdkPlugin: NSObject, FlutterPlugin {
       case .success(let dataBase64):
         result(dataBase64)
       case .failure(let error):
-        result(FlutterError(code: "ERROR_SIGNING",
+        result(FlutterError(code: String(describing: error),
                             message: "Chyba pri podpisovaní.",
                             details: error.localizedDescription))
       }

--- a/ios/eidmsdk.podspec
+++ b/ios/eidmsdk.podspec
@@ -4,12 +4,15 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'eidmsdk'
-  s.version          = '0.9.0'
+  s.version          = '0.9.1'
   s.summary          = 'eIDmSDK Flutter'
   s.description      = 'eIDmSDK wrapper for Flutter'
   s.homepage         = 'https://www.freevision.sk'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Ahmed Al Hafoudh' => 'alhafoudh@freevision.sk' }
+  s.author           = {
+                          'Ahmed Al Hafoudh' => 'alhafoudh@freevision.sk',
+                          'Matej Hlatky' => 'hlatky@freevision.sk'
+                       }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'

--- a/lib/eidmsdk.dart
+++ b/lib/eidmsdk.dart
@@ -1,6 +1,8 @@
-import 'package:eidmsdk/types.dart';
+import 'package:flutter/services.dart';
 
 import 'eidmsdk_platform_interface.dart';
+import 'errors.dart';
+import 'types.dart';
 
 class Eidmsdk {
   Future<bool> setLogLevel({
@@ -18,11 +20,23 @@ class Eidmsdk {
   Future<CertificatesInfo?> getCertificates({
     required List<EIDCertificateIndex> types,
     String? language,
-  }) =>
-      EidmsdkPlatform.instance.getCertificates(
+  }) async {
+    try {
+      return await EidmsdkPlatform.instance.getCertificates(
         types: types,
         language: language,
       );
+    } on PlatformException catch (e) {
+      switch (e.code) {
+        case "CertificateNotFoundException":
+        // TODO Implement sending code also in EidmsdkPlugin.swift
+        case "certificatesNotIssued":
+          throw CertificateNotFoundException(e.message ?? '', e.details);
+        default:
+          throw EidmsdkException(e.message ?? '', e.details);
+      }
+    }
+  }
 
   Future<String?> signData({
     required int certIndex,

--- a/lib/eidmsdk.dart
+++ b/lib/eidmsdk.dart
@@ -29,7 +29,6 @@ class Eidmsdk {
     } on PlatformException catch (e) {
       switch (e.code) {
         case "CertificateNotFoundException":
-        // TODO Implement sending code also in EidmsdkPlugin.swift
         case "certificatesNotIssued":
           throw CertificateNotFoundException(e.message ?? '', e.details);
         default:

--- a/lib/eidmsdk.dart
+++ b/lib/eidmsdk.dart
@@ -5,17 +5,11 @@ import 'errors.dart';
 import 'types.dart';
 
 class Eidmsdk {
-  Future<bool> setLogLevel({
-    required EIDLogLevel logLevel,
-  }) =>
-      EidmsdkPlatform.instance.setLogLevel(
-        logLevel: logLevel,
-      );
+  Future<bool> setLogLevel({required EIDLogLevel logLevel}) =>
+      EidmsdkPlatform.instance.setLogLevel(logLevel: logLevel);
 
   Future showTutorial({String? language}) =>
-      EidmsdkPlatform.instance.showTutorial(
-        language: language,
-      );
+      EidmsdkPlatform.instance.showTutorial(language: language);
 
   Future<CertificatesInfo?> getCertificates({
     required List<EIDCertificateIndex> types,
@@ -27,13 +21,7 @@ class Eidmsdk {
         language: language,
       );
     } on PlatformException catch (e) {
-      switch (e.code) {
-        case "CertificateNotFoundException":
-        case "certificatesNotIssued":
-          throw CertificateNotFoundException(e.message ?? '', e.details);
-        default:
-          throw EidmsdkException(e.message ?? '', e.details);
-      }
+      decodeNativeError(e);
     }
   }
 
@@ -43,12 +31,28 @@ class Eidmsdk {
     required String dataToSign,
     bool isBase64Encoded = false,
     String? language,
-  }) =>
-      EidmsdkPlatform.instance.signData(
+  }) async {
+    try {
+      return await EidmsdkPlatform.instance.signData(
         certIndex: certIndex,
         signatureScheme: signatureScheme,
         dataToSign: dataToSign,
         isBase64Encoded: isBase64Encoded,
         language: language,
       );
+    } on PlatformException catch (e) {
+      decodeNativeError(e);
+    }
+  }
+
+  static Never decodeNativeError(PlatformException e) {
+    switch (e.code) {
+      case "CertificateNotFoundException":
+      case "certificatesNotIssued":
+        throw CertificateNotFoundException(e.message ?? '', e.details);
+
+      default:
+        throw EidmsdkException(e.message ?? '', e.details);
+    }
+  }
 }

--- a/lib/errors.dart
+++ b/lib/errors.dart
@@ -1,0 +1,16 @@
+/// Base eID mSDK exception type.
+class EidmsdkException implements Exception {
+  final String message;
+  final dynamic details;
+
+  EidmsdkException(this.message, [this.details]);
+
+  @override
+  String toString() {
+    return "$runtimeType: $message";
+  }
+}
+
+class CertificateNotFoundException extends EidmsdkException {
+  CertificateNotFoundException(super.message, [super.details]);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: eidmsdk
 description: "eIDmSDK wrapper for Flutter"
-version: 0.9.0
+version: 0.9.1
 homepage: https://www.freevision.sk
 
 environment:


### PR DESCRIPTION
Pri volaniach nativnych Android a iOS **eID mSDK** funkcii sa posiela error code ako konkretny `String` z erroru.
 - Android: Java Exception type [`simpleName`](https://developer.android.com/reference/java/lang/Class#getSimpleName())
 - iOS: [`String(describing: error)`](https://developer.apple.com/documentation/swift/string/init(describing:)-67ncf)

Nasledne je mozne zname errory odchytit a rethrowuut ako custom Dart `EidmsdkException` a jeho derived typy.

Aktualne sa mapuje len:
- `CertificateNotFoundException` a `certificatesNotIssued` → `CertificateNotFoundException`

----

Related k: https://github.com/slovensko-digital/avm-app-flutter/issues/29